### PR TITLE
2021/02/02-18:38_リリース

### DIFF
--- a/.github/workflows/create_release_on_PR_closed.yml
+++ b/.github/workflows/create_release_on_PR_closed.yml
@@ -44,7 +44,7 @@ jobs:
             });
             console.log(create_release)
 
-            console.log("::set-output name=release_url::"+create_release.html_url)
+            console.log("::set-output name=release_url::"+create_release.data.html_url)
 
       - name: Slack Notification
         if: github.event.pull_request.merged == true


### PR DESCRIPTION
# リリース内容
## asanaタスク
- [[運用系・インフラ系] 本番で連続デプロイできるようにする](https://app.asana.com/0/1199606600307210/1199610384898445)
- [[v4] メール内のお問い合わせリンクを踏んだときv1にリダイレクトする処理を追加](https://app.asana.com/0/1199606600307210/1199558007649923)
- [[運用系・インフラ系] Splunk 用のログを出力 (2pt)](https://app.asana.com/0/1199606600307210/1199610384946248)
- [[リリース準備] トラッキングを仕込む](https://app.asana.com/0/1199606600307210/1187409830584547)
